### PR TITLE
Fix byte-compile warnings about unknown function

### DIFF
--- a/avandu.el
+++ b/avandu.el
@@ -53,6 +53,9 @@
 (require 'url)
 (require 'view)
 
+(declare-function w3m-region "w3m")
+(declare-function w3m-minor-mode "w3m")
+
 (defconst avandu-entity-replacement-alist
   '(("hellip" . 8230)
     ("qout" . 34)


### PR DESCRIPTION
This fixes following byte-compile warnings.

```
avandu.el:941:1:Warning: the following functions are not known to be defined: w3m-region,
    w3m-minor-mode
```